### PR TITLE
debug: cusp/detail/device/spmv/dia.h - device sparse diagonal matrix mul...

### DIFF
--- a/cusp/detail/device/spmv/dia.h
+++ b/cusp/detail/device/spmv/dia.h
@@ -87,7 +87,7 @@ spmv_dia_kernel(const IndexType num_rows,
             ValueType sum = (base == 0) ? ValueType(0) : y[row];
     
             // index into values array
-            IndexType idx = row + pitch * base;
+            IndexType idx = row * pitch + base;
     
             for(IndexType n = 0; n < chunk_size; n++)
             {
@@ -99,7 +99,7 @@ spmv_dia_kernel(const IndexType num_rows,
                     sum += A_ij * fetch_x<UseCache>(col, x);
                 }
         
-                idx += pitch;
+                idx ++;
             }
     
             y[row] = sum;


### PR DESCRIPTION
dia.h had a bug - two changes fixed it.  I have tested this fix.  See:

https://code.google.com/p/cusp-library/issues/detail?id=108
