### PR TITLE
Removed explicit keywords from array1d_view template constructors

### DIFF
--- a/cusp/array1d.h
+++ b/cusp/array1d.h
@@ -154,11 +154,11 @@ class array1d_view
       : m_begin(), m_size(0), m_capacity(0) {}
 
     template <typename Array>
-    explicit array1d_view(Array& a)
+    array1d_view(Array& a)
       : m_begin(a.begin()), m_size(a.size()), m_capacity(a.capacity()) {}
     
     template <typename Array>
-    explicit array1d_view(const Array& a)
+    array1d_view(const Array& a)
       : m_begin(a.begin()), m_size(a.size()), m_capacity(a.capacity()) {}
 
     // should these be templated?


### PR DESCRIPTION
This allows the implicit conversion of array1d to array1d_view when
passed as a function parameter. I know this a little against the
grain of C++, but isn't the point of the views to be used completely
interchangeably with the array types?
