### PR TITLE
Fix MSVC Compilation Error when using has_member_operator_exec_impl

### DIFF
--- a/cusp/system/detail/generic/multiply.inl
+++ b/cusp/system/detail/generic/multiply.inl
@@ -39,7 +39,116 @@ namespace generic
 {
 
 using namespace thrust::detail;
-__THRUST_DEFINE_IS_CALL_POSSIBLE(has_member_operator_exec_impl, operator())
+//__THRUST_DEFINE_IS_CALL_POSSIBLE(has_member_operator_exec_impl, operator())
+
+__THRUST_DEFINE_HAS_MEMBER_FUNCTION(has_member_operator_exec_imploperator, operator())
+
+struct yes {};
+struct no { yes m[2]; };
+
+template <typename T, typename Signature>
+struct has_member_operator_exec_impl
+{
+private:
+	//struct yes {};
+	//struct no { yes m[2]; };
+	struct derived : public T
+	{
+		using T::operator();
+		no operator()(...) const;
+	};
+
+	typedef typename thrust::detail::is_call_possible_detail::clone_constness<T, derived>::type derived_type;
+
+	template<typename U, typename Result>
+	struct return_value_check
+	{
+		static yes deduce(Result);
+		static no deduce(...);
+		static no deduce(no);
+		static no deduce(thrust::detail::is_call_possible_detail::void_exp_result<T>);
+	};
+
+	template<typename U>
+	struct return_value_check<U, void>
+	{
+		static yes deduce(...);
+		static no deduce(no);
+	};
+
+	template<bool has_the_member_of_interest, typename F>
+	struct impl
+	{
+		static const bool value = false;
+	};
+
+	template<typename Result, typename Arg>
+	struct impl<true, Result(Arg)>
+	{
+		static typename add_reference<derived_type>::type test_me;
+		static typename add_reference<Arg>::type          arg;
+
+		static const bool value =
+			sizeof(
+				return_value_check<T, Result>::deduce(
+				(test_me.operator()(arg), thrust::detail::is_call_possible_detail::void_exp_result<T>())
+				)
+				) == sizeof(yes);
+	};
+
+	template<typename Result, typename Arg1, typename Arg2>
+	struct impl<true, Result(Arg1, Arg2)>
+	{
+		static typename add_reference<derived_type>::type test_me;
+		static typename add_reference<Arg1>::type         arg1;
+		static typename add_reference<Arg2>::type         arg2;
+
+		static const bool value =
+			sizeof(
+				return_value_check<T, Result>::deduce(
+				(test_me.operator()(arg1, arg2), thrust::detail::is_call_possible_detail::void_exp_result<T>())
+				)
+				) == sizeof(yes);
+	};
+
+	template<typename Result, typename Arg1, typename Arg2, typename Arg3>
+	struct impl<true, Result(Arg1, Arg2, Arg3)>
+	{
+		static typename add_reference<derived_type>::type test_me;
+		static typename add_reference<Arg1>::type         arg1;
+		static typename add_reference<Arg2>::type         arg2;
+		static typename add_reference<Arg3>::type         arg3;
+
+		static const bool value =
+			sizeof(
+				return_value_check<T, Result>::deduce(
+				(test_me.operator()(arg1, arg2, arg3), thrust::detail::is_call_possible_detail::void_exp_result<T>())
+				)
+				) == sizeof(yes);
+
+	};
+
+	template<typename Result, typename Arg1, typename Arg2, typename Arg3, typename Arg4>
+	struct impl<true, Result(Arg1, Arg2, Arg3, Arg4)>
+	{
+		static typename add_reference<derived_type>::type test_me;
+		static typename add_reference<Arg1>::type         arg1;
+		static typename add_reference<Arg2>::type         arg2;
+		static typename add_reference<Arg3>::type         arg3;
+		static typename add_reference<Arg4>::type         arg4;
+
+		static const bool value =
+			sizeof(
+				return_value_check<T, Result>::deduce(
+				(test_me.operator()(arg1, arg2, arg3, arg4), thrust::detail::is_call_possible_detail::void_exp_result<T>())
+				)
+				) == sizeof(yes);
+	};
+
+public:
+	static const bool value = impl<has_member_operator_exec_imploperator<T, Signature>::value, Signature>::value;
+	typedef thrust::detail::integral_constant<bool, value> type;
+};
 
 template <typename DerivedPolicy,
           typename LinearOperator,


### PR DESCRIPTION
When compling the example multipy.cu, I got error C2923.
I managed to solve the problem by by modifying the has_member_operator_exec_impl in the cusp/system/detail/generic/multiply.inl.

Platform: Windows 10 and Visual Stuido 2017
cuda version: 9.0.176